### PR TITLE
Add CLI profile example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+You are an AI assistant specialized in Python development. Your approach emphasizes:
+
+1. Clear project structure with separate directories for source code, tests, docs, and config.
+2. Modular design with distinct files for models, services, controllers, and utilities.
+3. Configuration management using environment variables.
+4. Robust error handling and logging, including context capture.
+5. Detailed documentation using docstrings and README files.
+6. Dependency management via https://github.com/astral-sh/rye and virtual environments.
+7. Code style consistency using Ruff.
+8. AI-friendly coding practices:
+   - Descriptive variable and function names
+   - Type hints
+   - Detailed comments for complex logic
+   - Rich error context for debugging
+9. 문서와 코드 주석은 한국어로 작성해주세요.
+
+You provide code snippets and explanations tailored to these principles, optimizing for clarity and AI-assisted development.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# CLIck-Me-Codex4
+# CLI 개발자 소개 프로그램
+
+이 저장소는 `click`, `rich`, `pyfiglet`을 활용하여 개발자가 자신을 CLI 환경에서 소개할 수 있는 예제 프로그램을 제공합니다.
+
+## 실행 방법
+
+```bash
+python developer/cli-proflie.py
+```
+
+개발자 정보는 `developer/data.json` 파일에서 수정할 수 있습니다.

--- a/developer/cli-proflie.py
+++ b/developer/cli-proflie.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+import logging
+import click
+from rich.console import Console
+from rich.table import Table
+from pyfiglet import figlet_format
+
+# 로거 설정
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# 콘솔 객체 생성
+console = Console()
+
+
+def load_data(json_path: Path) -> dict:
+    """JSON 파일에서 개발자 정보를 불러온다."""
+    try:
+        with json_path.open("r", encoding="utf-8") as file:
+            data = json.load(file)
+            logger.debug("데이터 로드 성공: %s", data)
+            return data
+    except Exception as exc:  # 모든 예외 포착 후 로깅
+        logger.exception("데이터 로드 중 오류 발생")
+        raise exc
+
+
+@click.command()
+def main() -> None:
+    """CLI에서 개발자 프로필을 출력한다."""
+    data_path = Path(__file__).parent / "data.json"
+    data = load_data(data_path)
+
+    name: str = data.get("name", "")
+    intro: str = data.get("intro", "")
+    skills: list[str] = data.get("skills", [])
+
+    # 이름의 첫 글자들로 이니셜 생성
+    initials = "".join(word[0].upper() for word in name.split())
+
+    # pyfiglet을 이용한 이니셜 출력
+    console.print(figlet_format(initials, font="standard"))
+
+    # 자기소개 출력
+    console.print(f"[bold green]{intro}[/bold green]")
+
+    # 기술 스택 테이블 생성 및 출력
+    table = Table(title="기술 스택")
+    table.add_column("번호", justify="right")
+    table.add_column("기술명", style="cyan")
+    for idx, skill in enumerate(skills, start=1):
+        table.add_row(str(idx), skill)
+
+    console.print(table)
+
+
+if __name__ == "__main__":
+    main()

--- a/developer/data.json
+++ b/developer/data.json
@@ -1,0 +1,5 @@
+{
+  "name": "홍길동",
+  "intro": "주니어 파이썬 개발자 홍길동입니다.",
+  "skills": ["Python", "Click", "Rich", "Pyfiglet"]
+}


### PR DESCRIPTION
## Summary
- add AGENTS.md with coding guidelines
- introduce a simple CLI profile program using click, rich and pyfiglet
- store sample profile data in JSON
- document how to run the script

## Testing
- `python developer/cli-proflie.py` *(fails: ModuleNotFoundError: No module named 'rich')*
- `pip install click rich pyfiglet` *(fails: Could not connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_688770f501348327a5813280c2d6bfca